### PR TITLE
Added a clear action so you can clear the form

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,8 +47,13 @@ mapDispatchToProps takes a dispatch function and returns an object like so:
 ```jsx
 {
   actions: {
-    field1: { set: String -> () },
-    field2: { set: String -> () }
+    fields: {
+      field1: { set: String -> () },
+      field2: { set: String -> () }
+    },
+    form: {
+      clear: () -> ()
+    }
   }
 }
 ```
@@ -60,7 +65,8 @@ Example usage:
 
 ```jsx
 const props = mapDispatchToProps(dispatch);
-props.actions.field1.set("foo");
+props.actions.fields.field1.set("foo");
+props.actions.form.clear();
 ```
 
 ## Putting It Together With React
@@ -87,7 +93,7 @@ const MyForm = ({ actions, fields }) => (
       : "Field 1"}
     <input
       value={fields.field1.rawValue}
-      onChange={evt => actions.field1.set(evt.target.value)}
+      onChange={evt => actions.fields.field1.set(evt.target.value)}
       type="text"
     />
   </div>

--- a/examples/profiling-form/src/ProfilingForm.js
+++ b/examples/profiling-form/src/ProfilingForm.js
@@ -37,11 +37,16 @@ const ProfilingForm = ({ actions, fields }) => {
       key={fieldName}
       labelTextWhenNoError={fieldName}
       field={fields[fieldName]}
-      fieldActions={actions[fieldName]}
+      fieldActions={actions.fields[fieldName]}
       errorMessages={fieldErrorMessages}
     />
   ));
-  return <form>{fieldComponents}</form>;
+  return (
+    <div>
+      <button onClick={() => actions.form.clear()}>Clear the form</button>
+      {fieldComponents}
+    </div>
+  );
 };
 
 export default ProfilingForm;

--- a/examples/simple-form/src/SimpleForm.js
+++ b/examples/simple-form/src/SimpleForm.js
@@ -50,32 +50,33 @@ const InputField = ({
 );
 
 const SimpleForm = ({ actions, fields }) => (
-  <form>
+  <div>
     <InputField
       field={fields.name}
-      fieldActions={actions.name}
+      fieldActions={actions.fields.name}
       labelTextWhenNoError="name"
       errorMessages={nameFieldErrorMessages}
     />
     <InputField
       field={fields.confirmName}
-      fieldActions={actions.confirmName}
+      fieldActions={actions.fields.confirmName}
       labelTextWhenNoError="confirm name"
       errorMessages={confirmNameFieldErrorMessages}
     />
     <InputField
       field={fields.age}
-      fieldActions={actions.age}
+      fieldActions={actions.fields.age}
       labelTextWhenNoError="age"
       errorMessages={ageFieldErrorMessages}
     />
     <InputField
       field={fields.fourDigitCode}
-      fieldActions={actions.fourDigitCode}
+      fieldActions={actions.fields.fourDigitCode}
       labelTextWhenNoError="four digit code"
       errorMessages={fourDigitCodeErrorMessages}
     />
-  </form>
+    <button onClick={() => actions.form.clear()}>Clear the form</button>
+  </div>
 );
 
 export default SimpleForm;

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,9 @@ export const set = fieldName => value => ({
   payload: { fieldName, value }
 });
 
+export const CLEAR = "CLEAR";
+export const clear = () => ({ type: CLEAR });
+
 export const createFormReducer = formConfig => (
   state = createInitialState(formConfig),
   action
@@ -58,6 +61,18 @@ export const createFormReducer = formConfig => (
           draftState[fieldName].hasErrors = errors.length > 0;
         }
       });
+    case CLEAR:
+      return produce(state, draftState => {
+        const formConfigKeys = Object.keys(formConfig);
+        formConfigKeys.forEach(key => {
+          draftState[key] = {
+            dirty: false,
+            rawValue: formConfig[key].defaultValue || "",
+            validators: formConfig[key].validators || [],
+            constraints: formConfig[key].constraints || []
+          };
+        });
+      });
     default:
       return state;
   }
@@ -79,7 +94,7 @@ export const createMapDispatchToProps = formConfig => {
       };
     }
     cachedDispatch = dispatch;
-    cacheValue = { actions: dispatchObj };
+    cacheValue = { actions: dispatchObj, clear: () => dispatch(clear()) };
     return cacheValue;
   };
 };

--- a/src/main.js
+++ b/src/main.js
@@ -62,17 +62,7 @@ export const createFormReducer = formConfig => (
         }
       });
     case CLEAR:
-      return produce(state, draftState => {
-        const formConfigKeys = Object.keys(formConfig);
-        formConfigKeys.forEach(key => {
-          draftState[key] = {
-            dirty: false,
-            rawValue: formConfig[key].defaultValue || "",
-            validators: formConfig[key].validators || [],
-            constraints: formConfig[key].constraints || []
-          };
-        });
-      });
+      return createInitialState(formConfig);
     default:
       return state;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ export const set = fieldName => value => ({
   payload: { fieldName, value }
 });
 
-export const CLEAR = "CLEAR";
+export const CLEAR = "form/CLEAR";
 export const clear = () => ({ type: CLEAR });
 
 export const createFormReducer = formConfig => (
@@ -77,14 +77,16 @@ export const createMapDispatchToProps = formConfig => {
       return cacheValue;
     }
     let dispatchObj = {};
+    dispatchObj.fields = {};
     const keys = Object.keys(formConfig);
     for (let fieldName of keys) {
-      dispatchObj[fieldName] = {
+      dispatchObj.fields[fieldName] = {
         set: value => dispatch(set(fieldName)(value))
       };
     }
+    dispatchObj.form = { clear: () => dispatch(clear()) };
     cachedDispatch = dispatch;
-    cacheValue = { actions: dispatchObj, clear: () => dispatch(clear()) };
+    cacheValue = { actions: dispatchObj };
     return cacheValue;
   };
 };

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -10,7 +10,8 @@ import {
   createFormState,
   set,
   clear,
-  SET
+  SET,
+  CLEAR
 } from "../src/main";
 import {
   REQUIRED,
@@ -279,4 +280,45 @@ test("able to make change that does not violate constraints", t => {
     }
   };
   t.deepEqual(expectedState, formReducer(initialState, set("foo")("1")));
+});
+
+test("reducer clear action updates form to have a cleared state", t => {
+  const formState = {
+    foo: {
+      rawValue: "bar",
+      validators: [
+        {
+          type: REQUIRED,
+          args: [],
+          error: REQUIRED_ERROR
+        }
+      ],
+      constraints: [],
+      errors: [],
+      hasErrors: false,
+      dirty: true
+    }
+  };
+  const formReducer = createFormReducer(formState);
+  const initialState = initializeReducer(formReducer);
+  const clearedForm = {
+    foo: {
+      rawValue: "",
+      validators: [
+        {
+          type: REQUIRED,
+          args: [],
+          error: REQUIRED_ERROR
+        }
+      ],
+      constraints: [],
+      errors: [],
+      hasErrors: false,
+      dirty: false
+    }
+  };
+  t.deepEqual(
+    formReducer(initialState, { type: CLEAR }),
+    createInitialState(clearedForm)
+  );
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -301,7 +301,7 @@ test("reducer clear action updates form to have a cleared state", t => {
   };
   const formReducer = createFormReducer(formState);
   const initialState = initializeReducer(formReducer);
-  const clearedForm = {
+  const clearedFormState = {
     foo: {
       rawValue: "",
       validators: [
@@ -312,13 +312,10 @@ test("reducer clear action updates form to have a cleared state", t => {
         }
       ],
       constraints: [],
-      errors: [],
-      hasErrors: false,
+      errors: [REQUIRED_ERROR],
+      hasErrors: true,
       dirty: false
     }
   };
-  t.deepEqual(
-    formReducer(initialState, { type: CLEAR }),
-    createInitialState(clearedForm)
-  );
+  t.deepEqual(formReducer(initialState, { type: CLEAR }), clearedFormState);
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -9,6 +9,7 @@ import {
   createMapDispatchToProps,
   createFormState,
   set,
+  clear,
   SET
 } from "../src/main";
 import {
@@ -215,9 +216,10 @@ test("createMapDispatchToProps returns valid action creators", t => {
     baz: exampleRequiredField
   };
   const dispatchObj = createMapDispatchToProps(extendedFormConfig)(x => x);
-  t.deepEqual(dispatchObj.actions.foo.set("bar1"), set("foo")("bar1"));
-  t.deepEqual(dispatchObj.actions.bax.set("bar2"), set("bax")("bar2"));
-  t.deepEqual(dispatchObj.actions.baz.set("bar3"), set("baz")("bar3"));
+  t.deepEqual(dispatchObj.actions.fields.foo.set("bar1"), set("foo")("bar1"));
+  t.deepEqual(dispatchObj.actions.fields.bax.set("bar2"), set("bax")("bar2"));
+  t.deepEqual(dispatchObj.actions.fields.baz.set("bar3"), set("baz")("bar3"));
+  t.deepEqual(dispatchObj.actions.form.clear(), clear());
 });
 
 test("createMapDispatchToProps returns a memoized fn", t => {


### PR DESCRIPTION
## Description
I added a clear action so you can clear the form instantly. It will reset the formConfig what it is initially when the form would load. You can use this clear action if you wanted to clear the form when a user would click on another tab or did something specific on the page where you then wanted the form to clear and reset to its initial state
## Changes
- [x] added a clear action to clear out the form
- [x] nest actions under `form` and `fields`
- [x] updated examples to have clear button
- [x] updated docs to reflect changes

## Code of Conduct
https://github.com/CityBaseInc/redux-freeform/blob/master/CODE_OF_CONDUCT.md