### PR TITLE
validateWhen, numberGreaterThan, empty string case fixes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,8 +37,8 @@ other Redux app.
 mapStateToProps is an function for use with react-redux that takes the form state and returns an object
 
 ```jsx
-{ 
-  fields: state 
+{
+  fields: state;
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ mapStateToProps is an function for use with react-redux that takes the form stat
 
 ```jsx
 {
-  fields: state;
+  fields: state
 }
 ```
 

--- a/docs/validators-api.md
+++ b/docs/validators-api.md
@@ -92,6 +92,31 @@ Arguments:
 | "10"  | 11  | True      |
 | "15"  | 11  | False     |
 
+## numberGreaterThan
+
+numberGreaterThan will validate any number greater than the one provided
+
+```jsx
+import { numberGreaterThan } from "redux-freeform";
+
+const formConfig = {
+  age: {
+    validators: [numberGreaterThan(11)]
+  }
+};
+```
+
+Arguments:
+`numberGreaterThan(n)`
+
+- `n` value must be numerically `<` than _n_
+
+| Value | n   | Validates |
+| ----- | --- | --------- |
+| ""    | any | True      |
+| "10"  | 11  | False     |
+| "15"  | 11  | True      |
+
 ## hasLength
 
 hasLength will validate for any string of the given length

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -47,3 +47,19 @@ import { required } from "redux-freeform";
 
 fields.fieldName.errors.includes(required.error); // true if "fieldName" field has a "required" error
 ```
+
+## IMPORTANT NOTE:
+To allow for fields to be optional by default, we have chosen to only return errors for NON-empty input values. The exception to this is the `required` validator which returns false for empty and true for anything else and thus should be used on all required form fields.
+
+Internally, we break this rule for the when behavior. when takes another validator object as an argument to use as a predicate. Say field a has the following configuration:
+```jsx
+{
+  a: {
+    validators: [validateWhen(required(), onlyIntegers(), "b")]
+  },
+  b: {
+    validators: []
+  }
+```
+
+If `onlyIntegers` kept convention and validated `""`, a would be required by default as the precondition for when would be met causing `required` to validate against field a and reject. For this reason, any validator passed as the _second_ argument to validatedWhen (its precondition) will return false for an empty string to invert the default UX. In practice, this is more intuitive than it sounds.

--- a/examples/simple-form/src/SimpleForm.js
+++ b/examples/simple-form/src/SimpleForm.js
@@ -20,6 +20,9 @@ const ageFieldErrorMessages = {
   [onlyIntegers.error]: "age must be a whole number",
   [numberLessThan.error]: "age must be less than 99"
 };
+const maritalStatusErrorMessages = {
+  [required.error]: "marital status is required when over 18"
+};
 const fourDigitCodeErrorMessages = {
   [required.error]: "four digit code is required",
   [hasLength.error]: "four digit code must be 4 numbers"
@@ -73,6 +76,12 @@ const SimpleForm = ({ actions, fields }) => (
       fieldActions={actions.fields.age}
       labelTextWhenNoError="age"
       errorMessages={ageFieldErrorMessages}
+    />
+    <InputField
+      field={fields.maritalStatus}
+      fieldActions={actions.fields.maritalStatus}
+      labelTextWhenNoError="marriage status"
+      errorMessages={maritalStatusErrorMessages}
     />
     <InputField
       field={fields.fourDigitCode}

--- a/examples/simple-form/src/SimpleForm.js
+++ b/examples/simple-form/src/SimpleForm.js
@@ -31,6 +31,13 @@ const matchesRegexError = {
   [required.error]: "email is required",
   [matchesRegex.error]: "email is invalid"
 };
+const animalError = {
+  [required.error]: "animal type is required"
+};
+const animalNoiseError = a => ({
+  [matchesRegex.error]: `that's not what a ${a} sounds like`,
+  [required.error]: `animal noise is required`
+});
 
 const InputField = ({
   labelTextWhenNoError,
@@ -50,6 +57,38 @@ const InputField = ({
       value={field.rawValue}
       onChange={e => fieldActions.set(e.target.value)}
     />
+    {!field.dirty && " ✴️"}
+    {field.dirty && field.hasErrors && " ❌"}
+    {field.dirty && !field.hasErrors && " ✅"}
+    <p />
+  </div>
+);
+
+const InputDropDown = ({
+  labelTextWhenNoError,
+  field,
+  fieldActions,
+  errorMessages,
+  choices
+}) => (
+  <div>
+    <div>
+      <label>
+        {field.hasErrors
+          ? errorMessages[field.errors[0]]
+          : labelTextWhenNoError}
+      </label>
+    </div>
+    <select
+      value={field.rawValue}
+      onChange={e => fieldActions.set(e.target.value)}
+    >
+      {choices.map(c => (
+        <option key={c} value={c}>
+          {c}
+        </option>
+      ))}
+    </select>
     {!field.dirty && " ✴️"}
     {field.dirty && field.hasErrors && " ❌"}
     {field.dirty && !field.hasErrors && " ✅"}
@@ -94,6 +133,19 @@ const SimpleForm = ({ actions, fields }) => (
       fieldActions={actions.fields.regexMatch}
       labelTextWhenNoError="email"
       errorMessages={matchesRegexError}
+    />
+    <InputDropDown
+      field={fields.animal}
+      fieldActions={actions.fields.animal}
+      labelTextWhenNoError="animal"
+      errorMessages={animalError}
+      choices={["dog", "cat", "cow"]}
+    />
+    <InputField
+      field={fields.animalNoise}
+      fieldActions={actions.fields.animalNoise}
+      labelTextWhenNoError="animal noise"
+      errorMessages={animalNoiseError(fields.animal.rawValue)}
     />
     <button onClick={() => actions.form.clear()}>Clear the form</button>
   </div>

--- a/examples/simple-form/src/SimpleForm.state.js
+++ b/examples/simple-form/src/SimpleForm.state.js
@@ -35,6 +35,17 @@ const formConfig = {
   },
   regexMatch: {
     validators: [required(), matchesRegex("^[^s@]+@[^s@]+.[^s@]+$")] //simple regex to validate email address
+  },
+  animal: {
+    validators: [required()]
+  },
+  animalNoise: {
+    validators: [
+      validateWhen(required(), matchesRegex("^.+$"), "animal"),
+      validateWhen(matchesRegex("^woof$"), matchesRegex("^dog$"), "animal"),
+      validateWhen(matchesRegex("^meow$"), matchesRegex("^cat$"), "animal"),
+      validateWhen(matchesRegex("^moo$"), matchesRegex("^cow$"), "animal")
+    ]
   }
 };
 

--- a/examples/simple-form/src/SimpleForm.state.js
+++ b/examples/simple-form/src/SimpleForm.state.js
@@ -2,15 +2,22 @@ import {
   createFormState,
   matchesField,
   numberLessThan,
+  numberGreaterThan,
   onlyIntegers,
   hasLength,
   required,
-  matchesRegex
+  matchesRegex,
+  validateWhen
 } from "redux-freeform";
+
+console.log(validateWhen(required(), numberGreaterThan(18), "age"));
 
 const formConfig = {
   age: {
     validators: [required(), onlyIntegers(), numberLessThan(99)]
+  },
+  maritalStatus: {
+    validators: [validateWhen(required(), numberGreaterThan(18), "age")]
   },
   name: {
     validators: [required()]

--- a/examples/simple-form/src/SimpleForm.state.js
+++ b/examples/simple-form/src/SimpleForm.state.js
@@ -10,8 +10,6 @@ import {
   validateWhen
 } from "redux-freeform";
 
-console.log(validateWhen(required(), numberGreaterThan(18), "age"));
-
 const formConfig = {
   age: {
     validators: [required(), onlyIntegers(), numberLessThan(99)]

--- a/examples/simple-form/src/SimpleForm.state.js
+++ b/examples/simple-form/src/SimpleForm.state.js
@@ -34,7 +34,7 @@ const formConfig = {
     constraints: [onlyIntegers(), hasLength(0, 4)]
   },
   regexMatch: {
-    validators: [required(), matchesRegex("^[^\s@]+@[^\s@]+\.[^\s@]+$")] //simple regex to validate email address
+    validators: [required(), matchesRegex("^[^s@]+@[^s@]+.[^s@]+$")] //simple regex to validate email address
   }
 };
 

--- a/examples/simple-form/src/index.js
+++ b/examples/simple-form/src/index.js
@@ -15,6 +15,7 @@ const store = createStore(
 );
 const rootEl = document.getElementById("simple-form");
 const render = () =>
+  // eslint-disable-next-line react/no-render-return-value
   ReactDOM.render(
     <SimpleForm
       {...mapStateToProps(store.getState())}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ export {
   matchesField,
   hasLength,
   matchesRegex,
-  isRoutingNumber
+  isRoutingNumber,
+  validateWhen,
+  numberGreaterThan
 } from "./validation";
 export { createFormState } from "./main";

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-export const validatorToPredicate = (validatorFn, emptyCase) => (value, ...rest) =>
-  value === ""
-    ? emptyCase
-    : validatorFn(value, ...rest)
+export const validatorToPredicate = (validatorFn, emptyCase) => (
+  value,
+  ...rest
+) => (value === "" ? emptyCase : validatorFn(value, ...rest));

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,4 @@
+export const validatorToPredicate = (validatorFn, emptyCase) => (value, ...rest) =>
+  value === ""
+    ? emptyCase
+    : validatorFn(value, ...rest)

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -171,6 +171,7 @@ test("reducer set action re-validates dependent field", t => {
     }
   };
   t.deepEqual(expectedInitialState, initialState);
+  initialState.matchesFoo.rawValue = "baz";
   const expectedState = {
     foo: {
       rawValue: "bar",
@@ -187,7 +188,7 @@ test("reducer set action re-validates dependent field", t => {
       dirty: true
     },
     matchesFoo: {
-      rawValue: "",
+      rawValue: "baz",
       validators: [
         {
           type: MATCHES_FIELD,

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,20 @@
+import test from "ava";
+
+import { validatorFns, NUMBER_GREATER_THAN } from "../src/validation";
+import { validatorToPredicate } from "../src/util";
+
+test("validatorToPredicate will override empty string case of validator", t => {
+  const ngtPredicate = validatorToPredicate(
+    validatorFns[NUMBER_GREATER_THAN],
+    false
+  );
+  t.is(ngtPredicate("", ["0"], {}), false);
+});
+
+test("validatorToPredicate will run validator normally for non-empty string", t => {
+  const ngtPredicate = validatorToPredicate(
+    validatorFns[NUMBER_GREATER_THAN],
+    false
+  );
+  t.is(ngtPredicate("1", ["0"], {}), true);
+});


### PR DESCRIPTION
## Description
adding numberGreaterThan and validateWhen validators. validate when introduces a powerful new pattern of higher order validators and validator predicate conversion

## Changes
- [x] added numberGreaterThan validator
- [x] added validateWhen validator that runs a given validator once a precondition has been met. precondition is represented by another validator who's empty string case has been overwritten to return false
- [x] added util to convert validators to predicates with an overwritten empty string case
- [x] fixed issue where numberLessThan, matchesField, and matchesRegex weren't returning true for empty string
- [x] updated examples to use validateWhen and numberGreaterThan
- [x] updated docs to describe validateWhen
- [x] updated tests

## Code of Conduct
https://github.com/CityBaseInc/redux-freeform/blob/master/CODE_OF_CONDUCT.md