### PR TITLE
Remove optional chaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/src/validation.js
+++ b/src/validation.js
@@ -93,12 +93,12 @@ export const MATCHES_FIELD_ERROR = "error/MATCHES_FIELD";
 export const matchesField = createValidator(MATCHES_FIELD, MATCHES_FIELD_ERROR);
 validatorFns[MATCHES_FIELD] = (value, args, form) => {
   const dependentField = form[args[0]];
-  const dependentFieldValue = dependentField?.rawValue ?? "";
   if (dependentField === undefined) {
     throw new Error(
       `${args[0]} was passed to matchesField, but that field does not exist in the form`
     );
   }
+  const dependentFieldValue = dependentField.rawValue;
   return value === dependentFieldValue;
 };
 


### PR DESCRIPTION
## Description
Removes the optional chaining and nullish coalescing syntax from the matches field validator. Even though our other applications use this modern syntax just fine, when it was included in redux freeform everything started freaking out. 🤷 

