### PR TITLE
SRV-3051 :: Exp date constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.6.0-beta.3",
+  "version": "5.6.0-beta.4",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.5.0",
+  "version": "5.6.0-beta.0",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.6.0-beta.2",
+  "version": "5.6.0-beta.3",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.6.0-beta.0",
+  "version": "5.6.0-beta.1",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.6.0-beta.1",
+  "version": "5.6.0-beta.2",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.6.0-beta.4",
+  "version": "5.6.0",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -21,5 +21,6 @@ export {
   dateAfterToday,
   isValidMonth,
   includedIn,
+  onlyExpirationDate
 } from "./validation";
 export { createFormState } from "./main";

--- a/src/validation.js
+++ b/src/validation.js
@@ -38,6 +38,24 @@ export const ONLY_NATURALS_ERROR = "error/ONLY_NATURALS";
 export const onlyNaturals = createValidator(ONLY_NATURALS, ONLY_NATURALS_ERROR);
 validatorFns[ONLY_NATURALS] = (value, args, form) => /^(\d+)?$/.test(value);
 
+/* 
+07/22: experimental expiration date constraint
+should allow entry of expiration date using "/" character
+to accommodate browser autofill
+
+not tested as validation function
+to validate exp date instead use combo of:
+required(), hasLength(), isValidMonth(), dateAfterToday()
+*/
+export const ONLY_EXPIRATION_DATE = "validator/ONLY_EXPIRATION_DATE";
+export const ONLY_EXPIRATION_DATE_ERROR = "error/ONLY_EXPIRATION_DATE";
+export const onlyExpirationDate = createValidator(
+  ONLY_EXPIRATION_DATE,
+  ONLY_EXPIRATION_DATE_ERROR
+);
+validatorFns[ONLY_EXPIRATION_DATE] = (value, args, form) =>
+  /^(\d?\d?\/?\d?\d?)?$/.test(value);
+
 export const NUMBER_LESS_THAN = "validator/NUMBER_LESS_THAN";
 export const NUMBER_LESS_THAN_ERROR = "error/NUMBER_LESS_THAN";
 export const numberLessThan = createValidator(


### PR DESCRIPTION
## Description
Previously we were using the Only Naturals constraint for our CC Expiration Date field on Navigate's checkout and inserting the `/` via the formatted input formatter. This prevented browser autofill from working correctly, as `/` characters were disallowed from user input.

This PR creates a new constraint that allows only integers and the `/` character in an expiration date format `(MM/YY)` in order to enable browser autofill.

The comment above the new constraint specifies that it should not be used to validate expiration dates because it is necessarily more permissive (in order to enable all forms of input -- typing, autofill, and copy/paste) and does not validate that the digits entered correspond to a valid month/year in the future. Instead, users should combine several other validators in order to verify expiration dates.

## Code of Conduct
https://github.com/CityBaseInc/redux-freeform/blob/master/CODE_OF_CONDUCT.md
