### PR TITLE
PLFM-1467 Add `isPercentage` validator

### DIFF
--- a/docs/validators-api.md
+++ b/docs/validators-api.md
@@ -495,3 +495,27 @@ Arguments:
 | "pepsi"               | ["coca-cola", "pepsi"] | True      |
 | "rc-cola              | ["coca-cola", "pepsi"] | False     |
 
+## isPercentage
+
+isPercentage validates that a given string is a decimal OR whole number between 0 and 100. If a decimal is included, only tenths and hundredths place values are allowed.
+
+```jsx
+import { isPercentage } from "redux-freeform";
+
+const formConfig = {
+  service_fee: {
+    validators: [isPercentage()]
+  }
+};
+```
+
+| Value                 | Validates |
+| --------------------- | --------- |
+| ""                    | True      |
+| "23.52"               | True      |
+| "1"                   | True      |
+| "1.0"                 | True      |
+| "1.23"                | True      |
+| "1.238"               | False     |
+| "abc"                 | False     |
+| "$1.00"               | False     |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -22,5 +22,6 @@ export {
   isValidMonth,
   includedIn,
   onlyExpirationDate,
+  isPercentage,
 } from './validation';
 export { createFormState } from './main';

--- a/src/validation.js
+++ b/src/validation.js
@@ -17,6 +17,29 @@ dayjs.extend(isSameOrAfter);
 
 export let validatorFns = {};
 
+export const IS_PERCENTAGE = 'validator/IS_PERCENTAGE';
+export const IS_PERCENTAGE_ERROR = 'error/IS_PERCENTAGE';
+export const isPercentage = createValidator(IS_PERCENTAGE, IS_PERCENTAGE_ERROR);
+validatorFns[IS_PERCENTAGE] = (value, args, form) => {
+  if (value === '') {
+    return true;
+  }
+  const parts = value.split('.');
+  if (parts.length > 2) {
+    // Ensure there are 1 or 2 parts (integer and optional decimal)
+    return false;
+  }
+  const decimalPart = parts[1];
+  // If there's a decimal part, ensure it's 1 or 2 digits
+  if (decimalPart) {
+    if (decimalPart.length > 2 || isNaN(decimalPart)) {
+      return false;
+    }
+  }
+  const num = parseFloat(value);
+  return num >= 0 && num <= 100;
+};
+
 export const INCLUDED_IN = 'validator/INCLUDED_IN';
 export const INCLUDED_IN_ERROR = 'error/INCLUDED_IN';
 export const includedIn = createValidator(INCLUDED_IN, INCLUDED_IN_ERROR);

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -70,6 +70,7 @@ import {
   IS_PROBABLY_EMAIL_ERROR,
   IS_VALID_MONTH,
   IS_VALID_MONTH_ERROR,
+  IS_PERCENTAGE,
 } from '../src/validation';
 
 test('required validator produces correct validator object', (t) => {
@@ -1369,6 +1370,31 @@ testProp(
     t.true(validatorFns[HAS_SPECIAL_CHARACTER](`${stringA.join('')}`, [], {}));
   }
 );
+
+test('isPercentage accepts empty string', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE](''), true);
+});
+test('isPercentage accepts double digit decimals', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE]('23.52'), true);
+});
+test('isPercentage accepts whole numbers', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE]('5'), true);
+});
+test('isPercentage accepts tenths place values', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE]('1.0'), true);
+});
+test('isPercentage accepts hundredths place values', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE]('1.23'), true);
+});
+test('isPercentage does not accept alphabetical characters', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE]('abc'), false);
+});
+test('isPercentage does not accept beyond hundredths place values', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE]('1.238'), false);
+});
+test('isPercentage does not accept special characters', (t) => {
+  t.is(validatorFns[IS_PERCENTAGE]('$1.00'), false);
+});
 
 test('isProbablyEmail validator produces correct validator object', (t) => {
   t.is(isProbablyEmail.error, IS_PROBABLY_EMAIL_ERROR);


### PR DESCRIPTION
## Description
Adds a validator that can check when a stringified number is a percentage between 0-100. This will be initially pulled in by POS Config Tool but may be useful for other applications dealing with percentages.

## Changes
- [x] Add `isPercentage` validator

## Code of Conduct
https://github.com/CityBaseInc/redux-freeform/blob/master/CODE_OF_CONDUCT.md

## Screenshots
![image](https://github.com/CityBaseInc/redux-freeform/assets/100228853/a20fcf4c-3dc5-45a7-93a3-d08757e0e32a)
