### PR TITLE
WCHK-873 Add a validator for first names and last names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Freeform is a library that generates form management reducers for you. It handle
 it makes no decisions for how you display the form state. As such it does not necessarily depend upon
 React and could in theory be used with Angular or any other view library you're using with redux.
 
-Freeform supports a functional all-in approach to Redux apps. There are many benefits to keeping _all_ your state in Redux
-but it can be tedious to write out all the reducers and actions. By generating form reducers from simple configs we make
-this much more manageable.
+Freeform supports a functional all-in approach to Redux apps. There are many benefits to keeping _all_ your state in Redux but it can be tedious to write out all the reducers and actions. By generating form reducers from simple configs we make this much more manageable.
 
 Freeform takes a form configuration object and generates a `mapStateToProps`, `mapDispatchToProps`,
 and `reducer` for you to use at your leisure.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -22,5 +22,6 @@ export {
   isValidMonth,
   includedIn,
   onlyExpirationDate,
+  validName,
 } from './validation';
 export { createFormState } from './main';

--- a/src/validation.js
+++ b/src/validation.js
@@ -420,6 +420,14 @@ validatorFns[IS_PROBABLY_EMAIL] = (value, args, form) => {
   return new RegExp(/^\S+@\S+\.\S+$/).test(value);
 };
 
+export const VALID_NAME = 'validator/VALID_NAME';
+export const VALID_NAME_ERROR = 'validator/VALID_NAME_ERROR';
+export const validName = createValidator(VALID_NAME, VALID_NAME_ERROR);
+validatorFns[VALID_NAME] = (value, args, form) =>
+  value === ''
+    ? false
+    : new RegExp(/[A-zÀ-ÿ\-,'\S]+(\s?[A-zÀ-ÿ\-,'\S])*/).test(value);
+
 export const runValidatorErrorMessage = (type) =>
   `${type} was passed to runValidator, but that validator type does not exist. 
   Please check that you are only calling validator creator functions exported from 

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -70,6 +70,9 @@ import {
   IS_PROBABLY_EMAIL_ERROR,
   IS_VALID_MONTH,
   IS_VALID_MONTH_ERROR,
+  validName,
+  VALID_NAME,
+  VALID_NAME_ERROR,
 } from '../src/validation';
 
 test('required validator produces correct validator object', (t) => {
@@ -1286,6 +1289,55 @@ testProp(
     t.true(validatorFns[HAS_LOWERCASE_LETTER](`${stringA.join('')}`, [], {}));
   }
 );
+
+/**
+ * Tests for validName
+ */
+test('validName validator produces correct validator object', (t) => {
+  const invalidNameString = ` `;
+  t.is(validName.error, VALID_NAME_ERROR);
+  t.deepEqual(validName(invalidNameString), {
+    type: VALID_NAME,
+    args: [invalidNameString],
+    error: VALID_NAME_ERROR,
+  });
+});
+
+test('validName validator accepts when value is valid name', (t) => {
+  const validNameStrings = [
+    'John Smith',
+    'Nancy Moore-Klêne',
+    'Jien Xi',
+    'Brandon D. Jones',
+    'Ashley Q. W. McLeary',
+    'Mr. Jack Kirby',
+    'Dr. A. Petter Walter',
+    'Dw’t Hólmes III',
+    'Ms. Jenny',
+    'Emieral De Lassorel',
+    'Jón Einarsson',
+    'Rev. Yu McCallester',
+  ];
+  validNameStrings.map((validNameString) =>
+    t.is(validatorFns[VALID_NAME](validNameString, ['doesntmatter'], {}), true)
+  );
+});
+
+test('validName validator accepts a space between multiple names', (t) => {
+  t.is(validatorFns[VALID_NAME](`Mary Beth`, ['doesntmatter'], {}), true);
+});
+
+test('validName validator accepts an apostrophe', (t) => {
+  t.is(validatorFns[VALID_NAME](`O'Connor`, ['doesntmatter'], {}), true);
+});
+
+test('validName validator rejects an empty space', (t) => {
+  t.is(validatorFns[VALID_NAME](` `), false);
+});
+
+test('validName validator rejects an empty field', (t) => {
+  t.is(validatorFns[VALID_NAME](``), false);
+});
 
 test('hasUppercaseLetter validator produces correct validator object', (t) => {
   t.is(hasUppercaseLetter.error, HAS_UPPERCASE_LETTER_ERROR);


### PR DESCRIPTION
## Description

This is 1/3 PRs for the work needed to complete [WCHK-873](https://citybase.atlassian.net/browse/WCHK-873), a ticket to address an issue with users successfully registering in NFE with only blank spaces for their first and/or last names. This work adds a validator to redux freeform to check  that the input only contains spaces in conjunction with alpha characters or characters like an apostrophe, dash, and comma, etcetera., are valid as well. 

## Testing Environments

~[https://cityville-coconnor.dev.cityba.se/registration](https://cityville-coconnor.dev.cityba.se/registration)~

## Changes

- [x] Add `validName` validator
- [x] Add tests for invalid and valid cases of `validName` validator
- [x] Remove awkward README line breaks
- [x] Update library version in package.json

## Code of Conduct

https://github.com/CityBaseInc/redux-freeform/blob/master/CODE_OF_CONDUCT.md

## Concerns

- I may not have written the best regex for this... I am wondering if there are cases I missed, but a Google search wasn't very helpful.

## Screenshots

<img width="567" alt="Screenshot 2024-03-27 at 1 07 15 PM" src="https://github.com/CityBaseInc/redux-freeform/assets/111466539/4e652597-2ef4-40c8-8882-13928836a3c7">



[WCHK-873]: https://citybase.atlassian.net/browse/WCHK-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ