### PR TITLE
[WCHK-1754] Create new `includesPotentialCardNumber` validator

### DIFF
--- a/__tests__/validation.test.js
+++ b/__tests__/validation.test.js
@@ -1,6 +1,6 @@
 import { test, fc } from '@fast-check/jest';
 import dayjs from 'dayjs';
-import { expect } from '@jest/globals';
+import { expect, describe } from '@jest/globals';
 
 import { fieldNameGen } from '../test/util';
 import {
@@ -39,6 +39,9 @@ import {
   MATCHES_REGEX,
   MATCHES_REGEX_ERROR,
   matchesRegex,
+  includesPotentialCardNumber,
+  INCLUDES_POTENTIAL_CARD_NUMBER,
+  INCLUDES_POTENTIAL_CARD_NUMBER_ERROR,
   isRoutingNumber,
   IS_ROUTING_NUMBER,
   IS_ROUTING_NUMBER_ERROR,
@@ -111,6 +114,17 @@ test('noMoreThanSixNumbers validator produces correct validator object', () => {
     type: NO_MORE_THAN_SIX_NUMBERS,
     args: [],
     error: NO_MORE_THAN_SIX_NUMBERS_ERROR,
+  });
+});
+
+test('includesPotentialCardNumber validator produces correct validator object', () => {
+  expect(includesPotentialCardNumber.error).toBe(
+    INCLUDES_POTENTIAL_CARD_NUMBER_ERROR
+  );
+  expect(includesPotentialCardNumber()).toEqual({
+    type: INCLUDES_POTENTIAL_CARD_NUMBER,
+    args: [],
+    error: INCLUDES_POTENTIAL_CARD_NUMBER_ERROR,
   });
 });
 
@@ -680,6 +694,89 @@ test('noMoreThanSixNumbers rejects string with more than six numbers separated b
   expect(
     !validatorFns[NO_MORE_THAN_SIX_NUMBERS]('John Robertson 481375 203381 0349', {})
   ).toBe(true);
+});
+
+describe('includesPotentialCardNumber', () => {
+  test('validates a correct Luhn number', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532015112830366', {})
+    ).toBe(true);
+  });
+
+  test('validates a correct Luhn number with spaces', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532 0151 1283 0366', {})
+    ).toBe(true);
+  });
+
+  test('validates a correct Luhn number with hyphens', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532-0151-1283-0366', {})
+    ).toBe(true);
+  });
+
+  test('validates a correct Luhn number with leading zeros', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('00004532015112830366', {})
+    ).toBe(true);
+  });
+
+  test('validates a correct Luhn number with leading and trailing spaces', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER](' 4532015112830366 ', {})
+    ).toBe(true);
+  });
+
+  test('validates a correct Luhn number with mixed spaces and hyphens', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532-0151 1283-0366', {})
+    ).toBe(true);
+  });
+
+  test('validates a name + a correct Luhn number', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER](
+        'Adam 4111 1111 1111 1111 Smith',
+        {}
+      )
+    ).toBe(true);
+  });
+
+  test('invalidates an incorrect Luhn number', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532015112830367', {})
+    ).toBe(false);
+  });
+
+  test('invalidates an empty string', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('', {})).toBe(false);
+  });
+
+  test('invalidates a string with non-digit characters', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532a15112830366', {})
+    ).toBe(false);
+  });
+
+  test('invalidates a string with only non-digit characters', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('abcd', {})).toBe(false);
+  });
+
+  test('invalidates a string with mixed valid and invalid characters', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532a0151b283c0366', {})
+    ).toBe(false);
+  });
+
+  test('invalidates a string with only spaces', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('     ', {})).toBe(false);
+  });
+
+  test('invalidates a string with special characters (excluding hyphens)', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532@0151#1283$0366', {})
+    ).toBe(false);
+  });
 });
 
 test('numberLessThan accepts empty string', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export {
   dateAfterToday,
   isValidMonth,
   includedIn,
+  includesPotentialCardNumber,
   onlyExpirationDate,
   validName,
 } from './validation';


### PR DESCRIPTION
## Description

This validator is designed to reduce the accidental inclusion of credit card numbers in fields where they don't belong (e.g., the name field).

It identifies a potential credit card number based on the following criteria:
- It consists of 8 to 20 digits.
- Digits may be separated by optional spaces or hyphens.
- It must pass the Luhn algorithm check.

Note:
A string passing the Luhn algorithm is necessary but not sufficient to conclusively determine that the string is a valid credit card number.

For more details on the Luhn algorithm, refer to: https://stripe.com/en-ca/resources/more/how-to-use-the-luhn-algorithm-a-guide-in-applications-for-businesses#luhn-algorithm-formula

## Changes
- [x] Create new isPotentialCardNumber validator with specs

## Code of Conduct
https://github.com/CityBaseInc/redux-freeform/blob/master/CODE_OF_CONDUCT.md