### PR TITLE
[WCHK-1761] `includesPotentialCardNumber` adjustments

### DIFF
--- a/__tests__/validation.test.js
+++ b/__tests__/validation.test.js
@@ -697,84 +697,82 @@ test('noMoreThanSixNumbers rejects string with more than six numbers separated b
 });
 
 describe('includesPotentialCardNumber', () => {
-  test('validates a correct Luhn number', () => {
+  test('accepts a Name under 8 characters', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('Bob Fox', {})).toBe(true);
+  });
+
+  test('accepts a Name with spaces', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('Ron Swanson', {})).toBe(
+      true
+    );
+  });
+
+  test('accepts an incorrect Luhn number', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532015112830367', {})
+    ).toBe(true);
+  });
+
+  test('accepts an empty string', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('', {})).toBe(true);
+  });
+
+  test('accepts a string with only non-digit characters', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('abcd', {})).toBe(true);
+  });
+
+  test('accepts an incorrect Luhn number with non-digit characters', () => {
+    expect(
+      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532a0151b283c0366', {})
+    ).toBe(true);
+  });
+
+  test('accepts a string with only spaces', () => {
+    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('     ', {})).toBe(true);
+  });
+
+  test('rejects a correct Luhn number', () => {
     expect(
       validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532015112830366', {})
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  test('validates a correct Luhn number with spaces', () => {
+  test('rejects a correct Luhn number with spaces', () => {
     expect(
       validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532 0151 1283 0366', {})
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  test('validates a correct Luhn number with hyphens', () => {
+  test('rejects a correct Luhn number with hyphens', () => {
     expect(
       validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532-0151-1283-0366', {})
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  test('validates a correct Luhn number with leading zeros', () => {
+  test('rejects a correct Luhn number with leading zeros', () => {
     expect(
       validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('00004532015112830366', {})
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  test('validates a correct Luhn number with leading and trailing spaces', () => {
+  test('rejects a correct Luhn number with leading and trailing spaces', () => {
     expect(
       validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER](' 4532015112830366 ', {})
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  test('validates a correct Luhn number with mixed spaces and hyphens', () => {
+  test('rejects a correct Luhn number with mixed spaces and hyphens', () => {
     expect(
       validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532-0151 1283-0366', {})
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  test('validates a name + a correct Luhn number', () => {
+  test('rejects a name + a correct Luhn number', () => {
     expect(
       validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER](
         'Adam 4111 1111 1111 1111 Smith',
         {}
       )
-    ).toBe(true);
-  });
-
-  test('invalidates an incorrect Luhn number', () => {
-    expect(
-      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532015112830367', {})
-    ).toBe(false);
-  });
-
-  test('invalidates an empty string', () => {
-    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('', {})).toBe(false);
-  });
-
-  test('invalidates a string with non-digit characters', () => {
-    expect(
-      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532a15112830366', {})
-    ).toBe(false);
-  });
-
-  test('invalidates a string with only non-digit characters', () => {
-    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('abcd', {})).toBe(false);
-  });
-
-  test('invalidates a string with mixed valid and invalid characters', () => {
-    expect(
-      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532a0151b283c0366', {})
-    ).toBe(false);
-  });
-
-  test('invalidates a string with only spaces', () => {
-    expect(validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('     ', {})).toBe(false);
-  });
-
-  test('invalidates a string with special characters (excluding hyphens)', () => {
-    expect(
-      validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER]('4532@0151#1283$0366', {})
     ).toBe(false);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-freeform",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "A small Redux form library that supports purely functional apps, without magic",
   "main": "dist/redux-freeform.cjs.js",
   "module": "dist/redux-freeform.esm.js",

--- a/src/validation.js
+++ b/src/validation.js
@@ -149,7 +149,7 @@ validatorFns[INCLUDES_POTENTIAL_CARD_NUMBER] = (value) => {
   // A potential credit card number is a sequence of 8 to 20 digits, with optional spaces or hyphens between them
   const regexString = '(?:\\d[ -]*){8,20}';
   const regex = new RegExp(regexString);
-  return regex.test(value) && luhnValid(value);
+  return !(luhnValid(value) && regex.test(value));
 };
 
 export const NUMBER_LESS_THAN = 'validator/NUMBER_LESS_THAN';


### PR DESCRIPTION
## Description
After testing in Navigate, some minor adjustments were needed to this validator.

## Changes
- [x] Correct logic to not invalidate valid names, even if they are under 8 characters

## Code of Conduct
https://github.com/CityBaseInc/redux-freeform/blob/master/CODE_OF_CONDUCT.md

## Screenshots
Includes valid luhn number (rejected)
![image](https://github.com/user-attachments/assets/72f93c72-233c-4ddd-a779-4cbf3863556b)
Valid name under 8 chars (accepted)
![image](https://github.com/user-attachments/assets/17d162b6-fee8-4f3b-a228-e1ca4f9dd1ef)
